### PR TITLE
Added handling of non-JSON data

### DIFF
--- a/cloudify_hostpool/exceptions.py
+++ b/cloudify_hostpool/exceptions.py
@@ -17,6 +17,7 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     RESTful service exception handling
 '''
+import httplib
 
 
 class HostPoolHTTPException(Exception):
@@ -58,10 +59,26 @@ class HostNotFoundException(HostPoolHTTPException):
 
     def __init__(self, host_id):
         self.host_id = host_id
-        super(HostNotFoundException, self).__init__(404)
+        super(HostNotFoundException, self).__init__(httplib.NOT_FOUND)
 
     def __str__(self):
         return 'Cannot find requested host: {0}'.format(self.host_id)
+
+
+class UnexpectedData(HostPoolHTTPException):
+
+    """
+    Raised when there unexpected or unrecognized data sent
+    Common case: non-JSON requests to JSON endpoints
+
+    """
+
+    def __init__(self, message):
+        self.message = message
+        super(UnexpectedData, self).__init__(httplib.BAD_REQUEST)
+
+    def __str__(self):
+        return 'Unexpected data recieved: {0}'.format(self.message)
 
 
 class ConfigurationError(Exception):

--- a/cloudify_hostpool/rest/backend.py
+++ b/cloudify_hostpool/rest/backend.py
@@ -276,7 +276,7 @@ class RestBackend(object):
         self.logger.debug('backend.add_hosts({0})'.format(config))
         if not isinstance(config, dict) or \
            not config.get('hosts'):
-            raise exceptions.HostPoolHTTPException('Invalid hosts format')
+            raise exceptions.UnexpectedData('Empty hosts object')
         hosts = HostAlchemist(config).parse()
         return self.storage.add_hosts(hosts)
 
@@ -296,7 +296,7 @@ class RestBackend(object):
         if not host_id or not isinstance(host_id, int):
             raise exceptions.HostNotFoundException(host_id)
         if not isinstance(updates, dict):
-            raise exceptions.HostPoolHTTPException('Invalid data format')
+            raise exceptions.UnexpectedData('Updates must be a JSON object')
         orig = self.storage.get_host(host_id)
         if not orig:
             raise exceptions.HostNotFoundException(host_id)


### PR DESCRIPTION
This is the fix for the case when the user fails to send the header "Content-Type: application/json".  If a user sends in non-JSON data, the service will now return a 400 - BAD_REQUEST. 