### PR TITLE
CFY-6288 Use "error" as the error message key

### DIFF
--- a/cloudify_hostpool/exceptions.py
+++ b/cloudify_hostpool/exceptions.py
@@ -78,7 +78,7 @@ class UnexpectedData(HostPoolHTTPException):
         super(UnexpectedData, self).__init__(httplib.BAD_REQUEST)
 
     def __str__(self):
-        return 'Unexpected data recieved: {0}'.format(self.message)
+        return 'Unexpected data received: {0}'.format(self.message)
 
 
 class ConfigurationError(Exception):

--- a/cloudify_hostpool/rest/service.py
+++ b/cloudify_hostpool/rest/service.py
@@ -84,7 +84,7 @@ def handle_json_exception(exc):
     app.logger.debug('headers? {0}'.format(request.headers))
     if not request.data:
         return dict()
-    raise exceptions.HostPoolHTTPException(httplib.BAD_REQUEST)
+    raise exceptions.UnexpectedData(request.data)
 
 
 class Host(Resource):

--- a/cloudify_hostpool/rest/service.py
+++ b/cloudify_hostpool/rest/service.py
@@ -68,7 +68,7 @@ class Service(Api):
             app.logger.error('Exception.status_code: {0}'.format(
                 e.status_code))
             return self.make_response({
-                'message': str(e)
+                'error': str(e)
             }, e.status_code)
         return super(Service, self).handle_error(e)
 

--- a/cloudify_hostpool/tests/rest/test_service.py
+++ b/cloudify_hostpool/tests/rest/test_service.py
@@ -305,6 +305,9 @@ class ServiceTest(testtools.TestCase):
         result = self.app.post('/host/allocate',
                                data="{'os': 'linux'}")
         self.assertEqual(result.status_code, httplib.BAD_REQUEST)
+        response = json.loads(result.data)
+        self.assertIn('error', response)
+        self.assertIn('Unexpected data', response['error'])
 
     @mock.patch('cloudify_hostpool.rest.backend.RestBackend.host_port_scan',
                 _mock_scan_dead)

--- a/cloudify_hostpool/tests/rest/test_service.py
+++ b/cloudify_hostpool/tests/rest/test_service.py
@@ -282,6 +282,9 @@ class ServiceTest(testtools.TestCase):
                                data=json.dumps({'os': 'bados'}),
                                content_type='application/json')
         self.assertEqual(result.status_code, 515)
+        response = json.loads(result.data)
+        self.assertIn('error', response)
+        self.assertIn('Cannot acquire host', response['error'])
 
     @mock.patch('cloudify_hostpool.rest.backend.RestBackend.host_port_scan',
                 _mock_scan_alive)
@@ -291,6 +294,9 @@ class ServiceTest(testtools.TestCase):
                                data=json.dumps({'os': 1234}),
                                content_type='application/json')
         self.assertEqual(result.status_code, 515)
+        response = json.loads(result.data)
+        self.assertIn('error', response)
+        self.assertIn('Cannot acquire host', response['error'])
 
     @mock.patch('cloudify_hostpool.rest.backend.RestBackend.host_port_scan',
                 _mock_scan_alive)
@@ -306,6 +312,9 @@ class ServiceTest(testtools.TestCase):
         '''Tests allocate with no available hosts'''
         result = self.app.post('/host/allocate')
         self.assertEqual(result.status_code, 515)
+        response = json.loads(result.data)
+        self.assertIn('error', response)
+        self.assertIn('Cannot acquire host', response['error'])
 
 
 class ServiceConcurrencyTest(testtools.TestCase):


### PR DESCRIPTION
Both the plugin and the service need to use the same key for error
messages, to display errors correctly. Service was using "message",
while plugin was using "error". Let's use "error" in both.